### PR TITLE
Fix `Seq.groupWhen` bug 🪲 

### DIFF
--- a/src/FSharpAux/Array.fs
+++ b/src/FSharpAux/Array.fs
@@ -11,17 +11,17 @@ module Array =
         | null  -> nullArg argName 
         | _     -> ()
     
-    let inline contains x (arr : 'T []) =
-        let mutable found = false
-        let mutable i = 0
-        let eq = LanguagePrimitives.FastGenericEqualityComparer
+    //let inline contains x (arr : 'T []) =
+    //    let mutable found = false
+    //    let mutable i = 0
+    //    let eq = LanguagePrimitives.FastGenericEqualityComparer
 
-        while not found && i < arr.Length do
-            if eq.Equals(x, arr.[i]) then
-                found <- true
-            else
-                i <- i + 1
-        found
+    //    while not found && i < arr.Length do
+    //        if eq.Equals(x, arr.[i]) then
+    //            found <- true
+    //        else
+    //            i <- i + 1
+    //    found
     
     /// Builds a new array that contains every element of the input array except for that on position index.
     let removeIndex index (arr : 'T []) =

--- a/src/FSharpAux/Array.fs
+++ b/src/FSharpAux/Array.fs
@@ -5,6 +5,7 @@ module Array =
 
     open System
 
+    /// Checks if a give argument is not null and fails if it is.
     let inline checkNonNull argName arg = 
         match box arg with 
         | null  -> nullArg argName 
@@ -22,6 +23,7 @@ module Array =
                 i <- i + 1
         found
     
+    /// Builds a new array that contains every element of the input array except for that on position index.
     let removeIndex index (arr : 'T []) =
         if index < arr.Length then
             //Array.init (arr.Length - 2) (fun i -> if i <> index then arr.[i])
@@ -29,6 +31,7 @@ module Array =
         else
             invalidArg "index" "index not present in array"
 
+    /// Applies a function to each element of the array in between inclusively start and fin indices of the array, going backwards (from the end to the start), threading an accumulator argument through the computation. If the input function is f and the elements are i(start)...i(fin) then computes f i(start) (...(f i(fin)-1 i(fin))).
     let scanSubRight f (arr : _ []) start fin initState = 
         let mutable state = initState 
         let res = Array.create (2 + fin - start) initState 
@@ -38,7 +41,8 @@ module Array =
         done;
         res
 
-    let scanSubLeft f  initState (arr : _ []) start fin = 
+    /// Applies a function to each element in between inclusively start and fin indices of the array, threading an accumulator argument through the computation. If the input function is f and the elements are i(start)...i(fin) then computes f (... (f i(start) i(start + 1))...) i(fin). Raises ArgumentException if the array has size zero.
+    let scanSubLeft f initState (arr : _ []) start fin = 
         let mutable state = initState 
         let res = Array.create (2 + fin - start) initState 
         for i = start to fin do
@@ -47,12 +51,13 @@ module Array =
         done;
         res
 
-
+    /// Applies a function to each element of the array, threading an accumulator argument through the computation. If the input function is f and the elements are i0...iN then computes f (... (f i0 i1)...) iN and returns the intermediary and final results. Raises ArgumentException if the array has size zero.
     let scanReduce f (arr : _ []) = 
         let arrn = arr.Length
         if arrn = 0 then invalidArg "arr" "the input array is empty"
         else scanSubLeft f arr.[0] arr 1 (arrn - 1)
 
+    /// Applies a function to each element of the array, starting from the end, threading an accumulator argument through the computation. If the input function is f and the elements are i0...iN then computes f i0 (...(f iN-1 iN)) and returns the intermediary and final results.
     let scanReduceBack f (arr : _ [])  = 
         let arrn = arr.Length
         if arrn = 0 then invalidArg "arr" "the input array is empty"

--- a/src/FSharpAux/Array.fs
+++ b/src/FSharpAux/Array.fs
@@ -7,16 +7,16 @@ module Array =
 
     let inline checkNonNull argName arg = 
         match box arg with 
-        | null -> nullArg argName 
-        | _ -> ()
+        | null  -> nullArg argName 
+        | _     -> ()
     
-    let inline contains x (arr: 'T []) =
+    let inline contains x (arr : 'T []) =
         let mutable found = false
         let mutable i = 0
         let eq = LanguagePrimitives.FastGenericEqualityComparer
 
         while not found && i < arr.Length do
-            if eq.Equals(x,arr.[i]) then
+            if eq.Equals(x, arr.[i]) then
                 found <- true
             else
                 i <- i + 1
@@ -25,42 +25,42 @@ module Array =
     let removeIndex index (arr : 'T []) =
         if index < arr.Length then
             //Array.init (arr.Length - 2) (fun i -> if i <> index then arr.[i])
-            Array.ofSeq ( seq { for i = 0 to arr.Length - 1  do if i <> index then yield arr.[i] } )
+            Array.ofSeq (seq {for i = 0 to arr.Length - 1  do if i <> index then yield arr.[i]})
         else
             invalidArg "index" "index not present in array"
 
-    let scanSubRight f (arr : _[]) start fin initState = 
+    let scanSubRight f (arr : _ []) start fin initState = 
         let mutable state = initState 
-        let res = Array.create (2+fin-start) initState 
+        let res = Array.create (2 + fin - start) initState 
         for i = fin downto start do
             state <- f arr.[i] state;
             res.[i - start] <- state
         done;
         res
 
-    let scanSubLeft f  initState (arr : _[]) start fin = 
+    let scanSubLeft f  initState (arr : _ []) start fin = 
         let mutable state = initState 
-        let res = Array.create (2+fin-start) initState 
+        let res = Array.create (2 + fin - start) initState 
         for i = start to fin do
             state <- f state arr.[i];
-            res.[i - start+1] <- state
+            res.[i - start + 1] <- state
         done;
         res
 
 
-    let scanReduce f (arr : _[]) = 
+    let scanReduce f (arr : _ []) = 
         let arrn = arr.Length
         if arrn = 0 then invalidArg "arr" "the input array is empty"
         else scanSubLeft f arr.[0] arr 1 (arrn - 1)
 
-    let scanReduceBack f (arr : _[])  = 
+    let scanReduceBack f (arr : _ [])  = 
         let arrn = arr.Length
         if arrn = 0 then invalidArg "arr" "the input array is empty"
         else scanSubRight f arr 0 (arrn - 2) arr.[arrn - 1]
 
     
-    /// Stacks an array of arrays horizontaly
-    let stackHorizontal (arrs:array<array<'t>>) =
+    /// Stacks an array of arrays horizontally.
+    let stackHorizontal (arrs : array<array<'t>>) =
         let alength = arrs |> Array.map Array.length
         let aMinlength = alength |> Array.min
         let aMaxlength = alength |> Array.max
@@ -69,8 +69,8 @@ module Array =
         else
             invalidArg "arr" "the input arrays are of different length"
 
-    /// Stacks an array of arrays vertivaly
-    let stackVertical (arrs:array<array<'t>>) =    
+    /// Stacks an array of arrays vertically.
+    let stackVertical (arrs : array<array<'t>>) =    
         let alength = arrs |> Array.map Array.length
         let aMinlength = alength |> Array.min
         let aMaxlength = alength |> Array.max
@@ -81,7 +81,7 @@ module Array =
   
   
     /// Shuffels the input array (method: Fisher-Yates). Define the random number generator outside of a potential loop.
-    let shuffleFisherYates (rnd: System.Random) (arr : _[]) =
+    let shuffleFisherYates (rnd : System.Random) (arr : _[]) =
         let tmpArr = Array.copy arr
         for i = arr.Length downto 1 do
             // Pick random element to swap.
@@ -93,7 +93,7 @@ module Array =
         tmpArr  
         
     /// Shuffels the input array (method: Fisher-Yates) in place. Define the random number generator outside of a potential loop.
-    let shuffleInPlace (rnd: System.Random) (arr : _[]) =
+    let shuffleInPlace (rnd : System.Random) (arr : _[]) =
         for i = arr.Length downto 1 do
             // Pick random element to swap.
             let j = rnd.Next(i) // 0 <= j <= i-1
@@ -113,7 +113,7 @@ module Array =
 
     /// Returns an array of sliding windows of data drawn from the source array.
     /// Each window contains the n elements surrounding the current element.
-    let centeredWindow n (source: _ []) =    
+    let centeredWindow n (source : _ []) =    
         if n < 0 then invalidArg "n" "n must be a positive integer"
         let lastIndex = source.Length - 1
     
@@ -128,25 +128,25 @@ module Array =
         Array.mapi window source
     
     ///Applies a function to each element and its index of the array, threading an accumulator argument through the computation
-    let foldi (f : int -> 'State -> 'T -> 'State) (acc: 'State) (arr:'T[]) =
+    let foldi (f : int -> 'State -> 'T -> 'State) (acc : 'State) (arr : 'T[]) =
         let l = arr.Length
         let rec loop i acc = 
             if i = l then acc
-            else loop (i+1) (f i acc arr.[i])
+            else loop (i + 1) (f i acc arr.[i])
         loop 0 acc
 
     // Applies a function to each element of the sub-collection in range (iFrom - iTo), threading an accumulator argument through the computation.
-    let foldSub<'T,'State> (f : 'State -> 'T -> 'State) (acc: 'State) (arr:'T[]) iFrom iTo =
+    let foldSub<'T,'State> (f : 'State -> 'T -> 'State) (acc : 'State) (arr : 'T[]) iFrom iTo =
         checkNonNull "array" arr
         let f = OptimizedClosures.FSharpFunc<_,_,_>.Adapt(f)
         let mutable state = acc 
         //let len = array.Length
         for i = iFrom to iTo do
-            state <- f.Invoke(state,arr.[i])
+            state <- f.Invoke(state, arr.[i])
         state
 
     // Applies a function to each element of two sub-collections in range (iFrom - iTo), threading an accumulator argument through the computation.
-    let fold2Sub<'T1,'T2,'State>  f (acc: 'State) (arr1:'T1[]) (arr2:'T2 []) iFrom iTo =
+    let fold2Sub<'T1,'T2,'State>  f (acc : 'State) (arr1 : 'T1[]) (arr2 : 'T2 []) iFrom iTo =
         checkNonNull "array1" arr1
         checkNonNull "array2" arr2
         let f = OptimizedClosures.FSharpFunc<_,_,_,_>.Adapt(f)
@@ -154,23 +154,23 @@ module Array =
         let len = arr1.Length
         if len <> arr2.Length then invalidArg "array2" "Arrays must have same size."
         for i = iFrom to iTo do 
-            state <- f.Invoke(state,arr1.[i],arr2.[i])
+            state <- f.Invoke(state, arr1.[i], arr2.[i])
         state
 
-    ///Applies a keyfunction to each element and counts the amount of each distinct resulting key
-    let countDistinctBy (keyf : 'T -> 'Key) (arr: 'T array) =
+    /// Applies a keyfunction to each element and counts the amount of each distinct resulting key
+    let countDistinctBy (keyf : 'T -> 'Key) (arr : 'T array) =
         let dict = System.Collections.Generic.Dictionary<_, int ref> HashIdentity.Structural<'Key>
         // Build the distinct-key dictionary with count
         for v in arr do 
             let key = keyf v
             match dict.TryGetValue(key) with
             | true, count ->
-                    count := !count + 1 //If it matches a key in the dictionary increment by one
+                count := !count + 1 // If it matches a key in the dictionary increment by one
             | _ -> 
-                dict.[key] <- ref 1 //If it doesnt match create a new count for this key
-        //Write to array
+                dict.[key] <- ref 1 // If it doesn't match create a new count for this key
+        // Write to array
         [|
-        for v in dict do yield v.Key |> Operators.id,!v.Value
+        for v in dict do yield v.Key |> Operators.id, !v.Value
         |]
 
     /// Uses a binary search to retrieve an element out of the sorted array arr that fullfills a condition defined by the function compare.
@@ -182,7 +182,7 @@ module Array =
     /// If an element in the array is found that satisfies the condition returning 0, the index is returned.
     /// If the search ends within the array, the negative bitwise complement of the closest larger element is returned.
     /// If the element is bigger than the largest element of the array, the negative bitwise complement of the arr.lenght+1 is returned.
-    let binarySearchIndexBy compare (arr: 'a []) = 
+    let binarySearchIndexBy compare (arr : 'a []) = 
         if Array.isEmpty arr then failwith "Array cannot be empty." 
         else
             let rec loop lower upper = 
@@ -195,22 +195,22 @@ module Array =
                     elif comparisonResult < 0 then
                         loop lower (middle - 1)
                     else
-                        loop (middle + 1) upper           
-            loop 0 (arr.Length-1) 
+                        loop (middle + 1) upper
+            loop 0 (arr.Length - 1) 
 
 
     /// Iterates the data array beginning from the startIdx. 
     /// The step size and direction are implied by magnitude and sign of stepSize. The function returns
     /// the idx of the first value for which predicate returns true or the end/start of the collection
     /// is reached (returning None). 
-    let iterUntil (predicate: 'T -> bool) stepSize startIdx (arr: 'T []) =
-        let rec loop  (arr: 'T []) currentIdx =
+    let iterUntil (predicate : 'T -> bool) stepSize startIdx (arr : 'T []) =
+        let rec loop  (arr : 'T []) currentIdx =
             if currentIdx <= 0 then None
-            elif currentIdx >= arr.Length-1 then None
+            elif currentIdx >= arr.Length - 1 then None
             else                                              
                 match predicate arr.[currentIdx] with 
-                | true -> Some currentIdx   
-                | _               -> loop arr (currentIdx+stepSize) 
+                | true  -> Some currentIdx   
+                | _     -> loop arr (currentIdx + stepSize) 
         loop arr startIdx 
 
     /// Iterates the data array beginning from the startIdx. 
@@ -218,14 +218,14 @@ module Array =
     /// the idx of the first value for which predicate returns true or the end/start of the collection
     /// is reached (returning None). The predicate function takes the idx of the current value as an additional
     /// parameter.
-    let iterUntili (predicate: int -> 'T -> bool) stepSize startIdx (arr: 'T []) =
-        let rec loop  (arr: 'T []) currentIdx =
+    let iterUntili (predicate : int -> 'T -> bool) stepSize startIdx (arr : 'T []) =
+        let rec loop (arr: 'T []) currentIdx =
             if currentIdx <= 0 then None
-            elif currentIdx >= arr.Length-1 then None
+            elif currentIdx >= arr.Length - 1 then None
             else                                              
                 match predicate currentIdx arr.[currentIdx] with 
-                | true -> Some currentIdx   
-                | _               -> loop arr (currentIdx+stepSize) 
+                | true  -> Some currentIdx   
+                | _     -> loop arr (currentIdx + stepSize) 
         loop arr startIdx 
 
     /// Returns a new array containing only the elements of the input array for which the given predicate returns true.
@@ -328,13 +328,29 @@ module Array =
     /// Returns an array without every nth element of the input array.
     let skipNth (n : int) (array : 'T []) = filteri (fun i _ -> (i + 1) % n <> 0) array
 
+    /// Iterates over elements of the input array and groups adjacent elements.
+    /// A new group is started when the specified predicate holds about the element
+    /// of the array (and at the beginning of the iteration).
+    ///
+    /// For example: 
+    ///    Array.groupWhen isOdd [|3;3;2;4;1;2|] = [|[|3|]; [|3; 2; 4|]; [|1; 2|]|]
+    let groupWhen f (array : 'T []) =
+        let inds = findIndices f array
+        Array.init (inds.Length) (
+            fun i ->
+                if i + 1 = inds.Length then
+                    array.[Array.last inds ..]
+                else
+                    array.[inds.[i] .. inds.[i + 1] - 1]
+            )
+
 // ########################################
 // Static extensions
 
     type 'T ``[]`` with
         
         /// Look up an element in an array by index, returning a value if the index is in the domain of the array and default value if not
-        member this.TryFindDefault  (arr : _[]) (zero : 'value) (index : int) =
+        member this.TryFindDefault  (arr : _ []) (zero : 'value) (index : int) =
             match arr.Length > index with
             | true  -> arr.[index]
             | false -> zero

--- a/src/FSharpAux/List.fs
+++ b/src/FSharpAux/List.fs
@@ -250,6 +250,24 @@ module List =
     /// Returns a list without every nth element of the input list.
     let skipNth (n : int) (list : 'T list) = filteri (fun i _ -> (i + 1) % n <> 0) list
 
+    /// Iterates over elements of the input list and groups adjacent elements.
+    /// A new group is started when the specified predicate holds about the element
+    /// of the list (and at the beginning of the iteration).
+    ///
+    /// For example: 
+    ///    List.groupWhen isOdd [3;3;2;4;1;2] = [[3]; [3; 2; 4]; [1; 2]]
+    let groupWhen f list =
+        list
+        |> List.fold (
+            fun acc e ->
+                match f e, acc with
+                | true  , _         -> [e] :: acc       // true case
+                | false , h :: t    -> (e :: h) :: t    // false case, non-empty acc list
+                | false , _         -> [[e]]            // false case, empty acc list
+        ) []
+        |> List.map List.rev
+        |> List.rev
+
 // ########################################
 // Static extensions
 

--- a/src/FSharpAux/List.fs
+++ b/src/FSharpAux/List.fs
@@ -10,7 +10,7 @@ module List =
         | [] -> invalidArg "l" "the input list is empty"
         | (h::t) -> List.scan f h t
 
-    let scanArraySubRight<'T,'State> (f:FSharpFunc<'T,'State,'State>) (arr:_[]) start fin initState = 
+    let scanArraySubRight<'T,'State> (f : FSharpFunc<'T,'State,'State>) (arr : _ []) start fin initState = 
         let mutable state = initState  
         let mutable res = [state]  
         for i = fin downto start do
@@ -20,19 +20,19 @@ module List =
 
     let scanReduceBack f l = 
         match l with 
-        | [] -> invalidArg "l" "the input list is empty"
-        | _ -> 
+        | []    -> invalidArg "l" "the input list is empty"
+        | _     -> 
             let f = FSharpFunc<_,_,_>.Adapt(f)
             let arr = Array.ofList l 
             let arrn = Array.length arr 
             scanArraySubRight f arr 0 (arrn - 2) arr.[arrn - 1]
 
     
-    /// Cuts a list after N and returns both parts
+    /// Cuts a list after N and returns both parts.
     let cutAfterN n input = // Tail-recursive
         let rec gencut cur acc = function
-            | hd::tl when cur < n ->
-                gencut (cur+1) (hd::acc) tl
+            | hd :: tl when cur < n ->
+                gencut (cur + 1) (hd :: acc) tl
             | rest -> (List.rev acc), rest //need to reverse accumulator!
         gencut 0 [] input
 
@@ -52,63 +52,59 @@ module List =
 
 
 
-    /// Groups elements in list that are b function f
-    let groupEquals f (input:'a list) =
-        let rec groupLoop (first) (heap:'a list) (stack:'a list) (groupStack:'a list) =
+    /// Groups elements in the input list according to function f.
+    let groupEquals f (input : 'a list) =
+        let rec groupLoop (first) (heap : 'a list) (stack : 'a list) (groupStack : 'a list) =
             match heap with 
-            | head::rest -> if (f first head) then
-                                groupLoop first rest stack (head::groupStack)
-                            else
-                                groupLoop first rest (head::stack) groupStack
-                        
-            | []         -> stack,groupStack
-    
+            | head :: rest -> 
+                if (f first head) then
+                    groupLoop first rest stack (head :: groupStack)
+                else
+                    groupLoop first rest (head :: stack) groupStack
+            | [] -> stack,groupStack
 
-
-
-        let rec outerLoop (heap:'a list) (stack:list<'a list>) =
+        let rec outerLoop (heap : 'a list) (stack : list<'a list>) =
             match heap with 
-            | head::rest -> let filteredStack,groupStack = groupLoop head rest [] [head]
-                            outerLoop filteredStack (groupStack::stack)
-            | []         -> stack
-
-    
+            | head :: rest -> 
+                let filteredStack,groupStack = groupLoop head rest [] [head]
+                outerLoop filteredStack (groupStack :: stack)
+            | [] -> stack
 
         outerLoop input []
 
     
     // Example:
     // applyEachPairwise (+) ["A";"B";"C";"D";] --> ["AB"; "AC"; "AD"; "BC"; "BD"; "CD"]
-    /// Applies function f two each unique compination of items in list 
-    let applyEachPairwise (f: 'a -> 'a -> 'b ) (l : 'a list) =
+    /// Applies function f to each unique compination of items in the input list.
+    let applyEachPairwise (f : 'a -> 'a -> 'b) (l : 'a list) =
         let rec innerLoop hh ll acc =
             match ll with
-            | h::ll -> innerLoop hh ll ((f hh h)::acc)
-            | []    -> acc 
+            | h :: ll   -> innerLoop hh ll ((f hh h) :: acc)
+            | []        -> acc 
         let rec loop l' acc =
             match l' with
-            | h::tail -> loop tail (innerLoop h tail acc)
-            | []      -> acc |> List.rev
+            | h :: tail -> loop tail (innerLoop h tail acc)
+            | []        -> acc |> List.rev
         loop l []
 
 
     // Example:
     // applyEachPairwiseWith (+) ["A";"B";"C";"D";] --> ["AA"; "AB"; "AC"; "AD"; "BB"; "BC"; "BD"; "CC"; "CD"; "DD"]
-    /// Applies function f two each unique compination of items in list 
-    let applyEachPairwiseWith (f: 'a -> 'a -> 'b ) (l : 'a list) =
+    /// Applies function f two each unique compination of items in the input list.
+    let applyEachPairwiseWith (f : 'a -> 'a -> 'b) (l : 'a list) =
         let rec innerLoop hh ll acc =
             match ll with
-            | h::ll -> innerLoop hh ll ((f hh h)::acc)
-            | []    -> acc 
+            | h :: ll   -> innerLoop hh ll ((f hh h) :: acc)
+            | []        -> acc 
         let rec loop l' acc =
             match l' with
-            | h::tail -> loop tail (innerLoop h l' acc)
-            | []      -> acc |> List.rev
+            | h :: tail -> loop tail (innerLoop h l' acc)
+            | []        -> acc |> List.rev
         loop l []
 
     
-    /// Removes an element from a list at a given index
-    /// (Not recommended list opperation)
+    /// Removes an element from a list at a given index.
+    /// (Not recommended list operation)
     let removeAt index input =
       input 
       // Associate each element with a boolean flag specifying whether 
@@ -118,8 +114,8 @@ module List =
       |> List.filter fst |> List.map snd
 
 
-    /// Inserts an element into a list at a given index
-    /// (Not recommended list opperation)
+    /// Inserts an element into a list at a given index.
+    /// (Not recommended list operation)
     let insertAt index newEl input =
       // For each element, we generate a list of elements that should
       // replace the original one - either singleton list or two elements
@@ -127,15 +123,15 @@ module List =
       input |> List.mapi (fun i el -> if i = index then [newEl; el] else [el])
             |> List.concat
 
-    ///Applies a function to each element and its index of the list, threading an accumulator argument through the computation
-    let foldi (f : int -> 'State -> 'T -> 'State) (acc: 'State) (l:'T list) =
+    /// Applies a function to each element and its index of the list, threading an accumulator argument through the computation.
+    let foldi (f : int -> 'State -> 'T -> 'State) (acc : 'State) (l : 'T list) =
         let rec loop i acc l = 
             match l with
             | [] -> acc
-            | h :: t -> loop (i+1) (f i acc h) t
+            | h :: t -> loop (i + 1) (f i acc h) t
         loop 0 acc l
 
-    ///Applies a keyfunction to each element and counts the amount of each distinct resulting key
+    /// Applies a keyfunction to each element and counts the amount of each distinct resulting key.
     let countDistinctBy (keyf : 'T -> 'Key) (list: 'T list) =
         let dict = System.Collections.Generic.Dictionary<_, int ref> HashIdentity.Structural<'Key>
         // Build the distinct-key list with count
@@ -145,47 +141,44 @@ module List =
                 let key = keyf v
                 match dict.TryGetValue(key) with
                 | true, count ->
-                        count := !count + 1 //If it matches a key in the dictionary increment by one
+                    count := !count + 1 // If it matches a key in the dictionary increment by one
                 | _ -> 
-                    dict.[key] <- ref 1 //If it doesnt match create a new count for this key
+                    dict.[key] <- ref 1 // If it doesn't match create a new count for this key
                 loop t
             | _ -> ()
         loop list
         //Write to list
-        [
-        for v in dict do yield v.Key |> Operators.id,!v.Value
-        ]
+        [for v in dict do yield v.Key |> Operators.id, !v.Value]
 
 
-    ///TODO: add to seperate combinatorics module
+    // TODO: add to seperate combinatorics module
     /// Returns the power set of l (not including the empty set).
     let powerSetOf l = 
-        let rec loop (l: list<'a>) = 
+        let rec loop (l : list<'a>) = 
             match l with
-            | [] -> [[]] 
-            | x::xs -> List.collect (fun subSet -> [subSet; x::subSet]) (loop xs)
+            | []        -> [[]]
+            | x :: xs   -> List.collect (fun subSet -> [subSet; x :: subSet]) (loop xs)
         match loop l with
-        | h::t -> t
-        | h    -> h
+        | h :: t    -> t
+        | h         -> h
 
-    /// Treats l as a series of urns of which elements can be drawed from. Returns
+    /// Treats l as a series of turns of which elements can be drawed from. Returns
     /// a list including all combinations (different order is not considered) 
-    /// of elements if in one cycle one item is drawed of each urn. 
-    let drawExaustively (l:list<list<'a>>) =
+    /// of elements if in one cycle one item is drawed of each turn.
+    let drawExaustively (l : list<list<'a>>) =
         let rec loop acc l =
             match l with
-            | []    -> acc
-            | h::t  -> 
+            | []        -> acc
+            | h :: t    -> 
                 let tmp =
                     h
                     |> List.map (fun x -> acc |> List.map (fun y -> x::y)) 
                     |> List.concat
                 loop tmp t
         match l with 
-        | [] -> []
-        | h::[] -> h |> List.map (fun x -> [x])
-        | h::t ->
-            loop (h |> List.map (fun x -> [x])) t
+        | []        -> []
+        | h :: []   -> h |> List.map (fun x -> [x])
+        | h :: t    -> loop (h |> List.map (fun x -> [x])) t
 
     /// Returns a new list containing only the elements of the list for which the given predicate returns true.
     let filteri (predicate : int -> 'T -> bool) (list : 'T list) =
@@ -268,7 +261,7 @@ module FsharpListExtensions =
     type Microsoft.FSharp.Collections.List<'a > with //when 'a : equality
     
         //
-        static member iterWhile (f:'a -> bool) (ls:'a list) = 
+        static member iterWhile (f : 'a -> bool) (ls : 'a list) = 
             let rec iterLoop f ls = 
                 match ls with
                 | head :: tail -> if f head then iterLoop f tail

--- a/src/FSharpAux/List.fs
+++ b/src/FSharpAux/List.fs
@@ -5,11 +5,13 @@ open Microsoft.FSharp.Core.OptimizedClosures
 [<AutoOpen>]
 module List = 
     
+    /// Applies a function to each element of the list, threading an accumulator argument through the computation. If the input function is f and the elements are i0...iN then computes f (... (f i0 i1)...) iN and returns the intermediary and final results. Raises ArgumentException if the list has size zero.
     let scanReduce f l = 
         match l with 
         | [] -> invalidArg "l" "the input list is empty"
         | (h::t) -> List.scan f h t
 
+    /// Applies a function to each element of the array in between (inclusively) start and fin indices of the array, going backwards (from the end to the start), threading an accumulator argument through the computation. If the input function is f and the elements are i(start)...i(fin) then computes f i(start) (...(f i(fin)-1 i(fin))). Returns the result as a list.
     let scanArraySubRight<'T,'State> (f : FSharpFunc<'T,'State,'State>) (arr : _ []) start fin initState = 
         let mutable state = initState  
         let mutable res = [state]  
@@ -18,6 +20,7 @@ module List =
             res <- state :: res
         res
 
+    /// Applies a function to each element of the list, starting from the end, threading an accumulator argument through the computation. If the input function is f and the elements are i0...iN then computes f i0 (...(f iN-1 iN)) and returns the intermediary and final results.
     let scanReduceBack f l = 
         match l with 
         | []    -> invalidArg "l" "the input list is empty"

--- a/src/FSharpAux/Seq.fs
+++ b/src/FSharpAux/Seq.fs
@@ -54,24 +54,26 @@ module Seq =
             if en.MoveNext() then
                 if (f en.Current) then
                     let temp = en.Current
-                    loop (fun y -> 
-                        cont 
-                            (   match y with
+                    loop (fun y ->
+                        cont
+                            (
+                                match y with
                                 //| h :: t    -> [temp] :: h :: t
                                 | h :: t    -> [] :: (temp :: h) :: t   // remaining elements
                                 | []        -> [[temp]]                 // first element
                             )
-                         )
+                    )
                 else
-                    let temp = en.Current                    
-                    loop (fun y -> 
-                        cont 
-                            (   match y with
+                    let temp = en.Current
+                    loop (fun y ->
+                        cont
+                            (
+                                match y with
                                 | h :: t when t.Length = 0  -> [temp] :: h :: t // last element
                                 | h :: t                    -> (temp :: h) :: t // elements in between
                                 | []                        -> [[temp]]         // first element
                             )
-                         )
+                    )
             else
                 cont []
         // Remove when first element is empty due to "[] :: (temp :: h) :: t"

--- a/src/FSharpAux/Seq.fs
+++ b/src/FSharpAux/Seq.fs
@@ -48,7 +48,7 @@ module Seq =
     ///    Seq.groupWhen isOdd [3;3;2;4;1;2] = seq [[3]; [3; 2; 4]; [1; 2]]
     let groupWhen f (input:seq<'a>) =
         use en = input.GetEnumerator()
-
+    
         let rec loop cont =
             if en.MoveNext() then
                 if (f en.Current) then
@@ -56,9 +56,9 @@ module Seq =
                     loop (fun y -> 
                         cont 
                             (   match y with
-                                | h::t -> []::(temp::h)::t
+                                | h :: t    -> [] :: (temp :: h) :: t
                                 //| h::t -> [temp]::(h)::t
-                                | [] -> [[temp]]
+                                | []        -> [[temp]]
                             )
                          )
                 else
@@ -66,8 +66,9 @@ module Seq =
                     loop (fun y -> 
                         cont 
                             (   match y with
-                                | h::t -> (temp::h)::t
-                                | []   -> [[temp]]
+                                | h :: t when t.Length = 0  -> [temp] :: h :: t
+                                | h :: t                    -> (temp :: h) :: t
+                                | []                        -> [[temp]]
                             )
                          )
             else
@@ -80,7 +81,7 @@ module Seq =
                       | _  -> h::t
             | [] -> []
             |> Seq.cast
-
+    
         tmp
 
 

--- a/tests/FSharpAux.Tests/Array2DTests.fs
+++ b/tests/FSharpAux.Tests/Array2DTests.fs
@@ -119,7 +119,7 @@ let array2dTests =
             testCase "returns correct 2D array" (fun _ ->
                 Expect.equal (testArr2d1 |> Array2D.rotate90DegClockwise) testArr2d_rotate90DegClockwise_Equal "Array2D.rotate90DegClockwise did return correct array"
             )
-            testCase "returns incorrect 2D array" (fun _ ->
+            testCase "does not return incorrect 2D array" (fun _ ->
                 Expect.notEqual (testArr2d1 |> Array2D.rotate90DegClockwise) testArr2d_rotate90DegClockwise_NotEqual "Array2D.rotate90DegClockwise did not return incorrect array"
             )
         ]
@@ -127,7 +127,7 @@ let array2dTests =
             testCase "returns correct 2D array" (fun _ ->
                 Expect.equal (testArr2d1 |> Array2D.rotate90DegCounterClockwise) testArr2d_rotate90DegCounterClockwise_Equal "Array2D.rotate90DegCounterClockwise did return correct array"
             )
-            testCase "returns incorrect 2D array" (fun _ ->
+            testCase "does not return incorrect 2D array" (fun _ ->
                 Expect.notEqual (testArr2d1 |> Array2D.rotate90DegCounterClockwise) testArr2d_rotate90DegCounterClockwise_NotEqual "Array2D.rotate90DegCounterClockwise did not return incorrect array"
             )
         ]
@@ -135,7 +135,7 @@ let array2dTests =
             testCase "returns correct 2D array" (fun _ ->
                 Expect.equal (testArr2d1 |> Array2D.rotate180Deg) testArr2d_rotate180Deg_Equal "Array2D.rotate180Deg did return correct array"
             )
-            testCase "returns incorrect 2D array" (fun _ ->
+            testCase "does not return incorrect 2D array" (fun _ ->
                 Expect.notEqual (testArr2d1 |> Array2D.rotate180Deg) testArr2d_rotate180Deg_NotEqual "Array2D.rotate180Deg did not return incorrect array"
             )
         ]
@@ -143,7 +143,7 @@ let array2dTests =
             testCase "returns correct 2D array" (fun _ ->
                 Expect.equal (testArr2d1 |> Array2D.flipHorizontally) testArr2d_flipHorizontally_Equal "Array2D.flipHorizontally did return correct array"
             )
-            testCase "returns incorrect 2D array" (fun _ ->
+            testCase "does not return incorrect 2D array" (fun _ ->
                 Expect.notEqual (testArr2d1 |> Array2D.flipHorizontally) testArr2d_flipHorizontally_NotEqual "Array2D.flipHorizontally did not return incorrect array"
             )
         ]
@@ -151,7 +151,7 @@ let array2dTests =
             testCase "returns correct 2D array" (fun _ ->
                 Expect.equal (testArr2d1 |> Array2D.flipVertically) testArr2d_flipVertically_Equal "Array2D.flipVertically did return correct array"
             )
-            testCase "returns incorrect 2D array" (fun _ ->
+            testCase "does not return incorrect 2D array" (fun _ ->
                 Expect.notEqual (testArr2d1 |> Array2D.flipVertically) testArr2d_flipVertically_NotEqual "Array2D.flipVertically did not return incorrect array"
             )
         ]
@@ -159,7 +159,7 @@ let array2dTests =
             testCase "returns correct 2D array" (fun _ ->
                 Expect.equal (testArr2d1 |> Array2D.toIndexedArray) testArr2d_toIndexedArray_Equal "Array2D.toIndexedArray did return correct array"
             )
-            testCase "returns incorrect 2D array" (fun _ ->
+            testCase "does not return incorrect 2D array" (fun _ ->
                 Expect.notEqual (testArr2d1 |> Array2D.toIndexedArray) testArr2d_toIndexedArray_NotEqual "Array2D.toIndexedArray did not return incorrect array"
             )
         ]

--- a/tests/FSharpAux.Tests/ArrayTests.fs
+++ b/tests/FSharpAux.Tests/ArrayTests.fs
@@ -17,6 +17,8 @@ let testArray1_takeNth_Equal            = [|23; 1; 1000|]
 let testArray1_takeNth_NotEqual         = [|5; 6; 7; 10|]
 let testArray1_skipNth_Equal            = [|1337; 14; 23; 69; 2; 3; 9001; 23|]
 let testArray1_skipNth_NotEqual         = [|5; 6; 7; 10|]
+let testArray1_groupWhen_Equal          = [|[|1337; 14|]; [|23|]; [|23|]; [|69|]; [|1; 2|]; [|3; 1000|]; [|9001|]; [|23|]|]
+let testArray1_groupWhen_NotEqual       = [|[|1337; 14|]; [|23|]; [|23|]; [|69|]; [|1; 2|]; [|3; 1000|]; [|9001; 23|]|]
 
 [<Tests>]
 let arrayTests =
@@ -83,6 +85,15 @@ let arrayTests =
             )
             testCase "returns incorrect array" (fun _ ->
                 Expect.notEqual (testArray1 |> Array.skipNth 3) testArray1_skipNth_NotEqual "Array.skipNth did not return incorrect array"
+            )
+        ]
+        testList "Array.groupWhen" [
+            let isOdd n = n % 2 <> 0
+            testCase "returns correct jagged array" (fun _ ->
+                Expect.equal (testArray1 |> Array.groupWhen isOdd) testArray1_groupWhen_Equal "Array.groupWhen did return correct jagged array"
+            )
+            testCase "returns incorrect jagged array" (fun _ ->
+                Expect.notEqual (testArray1 |> Array.groupWhen isOdd) testArray1_groupWhen_NotEqual "Array.groupWhen did not return incorrect jagged array"
             )
         ]
     ]

--- a/tests/FSharpAux.Tests/ArrayTests.fs
+++ b/tests/FSharpAux.Tests/ArrayTests.fs
@@ -27,7 +27,7 @@ let arrayTests =
             testCase "returns correct array" (fun _ ->
                 Expect.equal (testArray1 |> Array.filteri (fun i t -> i < 5 && t < 100)) testArray1_filteri_Equal "Array.filteri did return correct array"
             )
-            testCase "returns incorrect array" (fun _ ->
+            testCase "does not return incorrect array" (fun _ ->
                 Expect.notEqual (testArray1 |> Array.filteri (fun i t -> i < 5 && t < 100)) testArray1_filteri_NotEqual "Array.filteri did not return incorrect array"
             )
         ]
@@ -35,7 +35,7 @@ let arrayTests =
             testCase "returns correct array" (fun _ ->
                 Expect.equal (testArray1 |> Array.countByPredicate (fun t -> t < 100)) 8 "Array.countByPredicate did return correct integer"
             )
-            testCase "returns incorrect array" (fun _ ->
+            testCase "does not return incorrect array" (fun _ ->
                 Expect.notEqual (testArray1 |> Array.countByPredicate (fun t -> t < 100)) 5 "Array.countByPredicate did not return incorrect integer"
             )
         ]
@@ -43,7 +43,7 @@ let arrayTests =
             testCase "returns correct array" (fun _ ->
                 Expect.equal (testArray1 |> Array.countiByPredicate (fun i t -> i < 5 && t < 100)) 4 "Array.countiByPredicate did return correct integer"
             )
-            testCase "returns incorrect array" (fun _ ->
+            testCase "does not return incorrect array" (fun _ ->
                 Expect.notEqual (testArray1 |> Array.countiByPredicate (fun i t -> i < 5 && t < 100)) 1 "Array.countiByPredicate did not return incorrect integer"
             )
         ]
@@ -51,7 +51,7 @@ let arrayTests =
             testCase "returns correct array" (fun _ ->
                 Expect.equal (testArray1 |> Array.choosei (fun i t -> if i < 5 && t < 100 then Some (float t) else None)) testArray1_choosei_Equal "Array.choosei did return correct array"
             )
-            testCase "returns incorrect array" (fun _ ->
+            testCase "does not return incorrect array" (fun _ ->
                 Expect.notEqual (testArray1 |> Array.choosei (fun i t -> if i < 5 && t < 100 then Some (float t) else None)) testArray1_choosei_NotEqual "Array.choosei did not return incorrect array"
             )
         ]
@@ -59,7 +59,7 @@ let arrayTests =
             testCase "returns correct array" (fun _ ->
                 Expect.equal (testArray1 |> Array.findIndices (fun t -> t < 100)) testArray1_findIndices_Equal "Array.findIndices did return correct array"
             )
-            testCase "returns incorrect array" (fun _ ->
+            testCase "does not return incorrect array" (fun _ ->
                 Expect.notEqual (testArray1 |> Array.findIndices (fun t -> t < 100)) testArray1_findIndices_NotEqual "Array.findIndices did not return incorrect array"
             )
         ]
@@ -67,7 +67,7 @@ let arrayTests =
             testCase "returns correct array" (fun _ ->
                 Expect.equal (testArray1 |> Array.findIndicesBack (fun t -> t < 100)) testArray1_findIndicesBack_Equal "Array.findIndicesBack did return correct array"
             )
-            testCase "returns incorrect array" (fun _ ->
+            testCase "does not return incorrect array" (fun _ ->
                 Expect.notEqual (testArray1 |> Array.findIndicesBack (fun t -> t < 100)) testArray1_findIndicesBack_NotEqual "Array.findIndicesBack did not return incorrect array"
             )
         ]
@@ -75,7 +75,7 @@ let arrayTests =
             testCase "returns correct array" (fun _ ->
                 Expect.equal (testArray1 |> Array.takeNth 3) testArray1_takeNth_Equal "Array.takeNth did return correct array"
             )
-            testCase "returns incorrect array" (fun _ ->
+            testCase "does not return incorrect array" (fun _ ->
                 Expect.notEqual (testArray1 |> Array.takeNth 3) testArray1_takeNth_NotEqual "Array.takeNth did not return incorrect array"
             )
         ]
@@ -83,7 +83,7 @@ let arrayTests =
             testCase "returns correct array" (fun _ ->
                 Expect.equal (testArray1 |> Array.skipNth 3) testArray1_skipNth_Equal "Array.skipNth did return correct array"
             )
-            testCase "returns incorrect array" (fun _ ->
+            testCase "does not return incorrect array" (fun _ ->
                 Expect.notEqual (testArray1 |> Array.skipNth 3) testArray1_skipNth_NotEqual "Array.skipNth did not return incorrect array"
             )
         ]
@@ -92,7 +92,7 @@ let arrayTests =
             testCase "returns correct jagged array" (fun _ ->
                 Expect.equal (testArray1 |> Array.groupWhen isOdd) testArray1_groupWhen_Equal "Array.groupWhen did return correct jagged array"
             )
-            testCase "returns incorrect jagged array" (fun _ ->
+            testCase "does not return incorrect jagged array" (fun _ ->
                 Expect.notEqual (testArray1 |> Array.groupWhen isOdd) testArray1_groupWhen_NotEqual "Array.groupWhen did not return incorrect jagged array"
             )
         ]

--- a/tests/FSharpAux.Tests/FSharpAux.Tests.fsproj
+++ b/tests/FSharpAux.Tests/FSharpAux.Tests.fsproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="SeqTests.fs" />
     <Compile Include="ArrayTests.fs" />
     <Compile Include="Array2DTests.fs" />
     <Compile Include="JaggedArrayTest.fs" />

--- a/tests/FSharpAux.Tests/JaggedArrayTest.fs
+++ b/tests/FSharpAux.Tests/JaggedArrayTest.fs
@@ -40,7 +40,7 @@ let jaggedArrayTests =
             testCase "returns correct array" (fun _ ->
                 Expect.equal (testJaggArr1 |> JaggedArray.toIndexedArray) testJaggArr1_toIndexedArray_Equal "JaggedArray.toIndexedArray did return correct array"
             )
-            testCase "returns incorrect array" (fun _ ->
+            testCase "does not return incorrect array" (fun _ ->
                 Expect.notEqual (testJaggArr1 |> JaggedArray.toIndexedArray) testJaggArr1_toIndexedArray_NotEqual "JaggedArray.toIndexedArray did not return incorrect array"
             )
         ]
@@ -48,7 +48,7 @@ let jaggedArrayTests =
             testCase "returns correct jagged array" (fun _ ->
                 Expect.equal (testArr2d1 |> JaggedArray.ofArray2D) testArr2d1_ofArray2D_Equal "JaggedArray.ofArray2D did return correct jagged array"
             )
-            testCase "returns incorrect jagged array" (fun _ ->
+            testCase "does not return incorrect jagged array" (fun _ ->
                 Expect.notEqual (testArr2d1 |> JaggedArray.ofArray2D) testArr2d1_ofArray2D_NotEqual "JaggedArray.ofArray2D did not return incorrect jagged array"
             )
         ]
@@ -56,7 +56,7 @@ let jaggedArrayTests =
             testCase "returns correct jagged array" (fun _ ->
                 Expect.equal (JaggedArray.init 3 7 (fun i j -> i * 2, j * 3)) testJaggArr1_init_Equal "JaggedArray.init did return correct jagged array"
             )
-            testCase "returns incorrect jagged array" (fun _ ->
+            testCase "does not return incorrect jagged array" (fun _ ->
                 Expect.notEqual (JaggedArray.init 3 7 (fun i j -> i * 2, j * 3)) testJaggArr1_init_NotEqual "JaggedArray.init did not return incorrect jagged array"
             )
         ]
@@ -81,7 +81,7 @@ let jaggedListTests =
             testCase "returns correct list" (fun _ ->
                 Expect.equal (JaggedList.init 3 7 (fun i j -> i * 2, j * 3)) testJaggList1_init_Equal "JaggedList.init did return correct list"
             )
-            testCase "returns incorrect list" (fun _ ->
+            testCase "does not return incorrect list" (fun _ ->
                 Expect.notEqual (JaggedList.init 3 7 (fun i j -> i * 2, j * 3)) testJaggList1_init_NotEqual "JaggedList.init did not return incorrect list"
             )
         ]

--- a/tests/FSharpAux.Tests/ListTests.fs
+++ b/tests/FSharpAux.Tests/ListTests.fs
@@ -3,20 +3,22 @@
 open FSharpAux
 open Expecto
 
-let testList1                          = [1337; 14; 23; 23; 69; 1; 2; 3; 1000; 9001; 23]
-
-let testList1_filteri_Equal            = [14; 23; 23; 69]
-let testList1_filteri_NotEqual         = [1337; 14; 23;]
-let testList1_choosei_Equal            = [14.; 23.; 23.; 69.]
-let testList1_choosei_NotEqual         = [1337.; 14.; 23.;]
-let testList1_findIndices_Equal        = [1; 2; 3; 4; 5; 6; 7; 10]
-let testList1_findIndices_NotEqual     = [5; 6; 7; 10]
-let testList1_findIndicesBack_Equal    = [10; 7; 6; 5; 4; 3; 2; 1]
-let testList1_findIndicesBack_NotEqual = [5; 6; 7; 10]
-let testList1_takeNth_Equal            = [23; 1; 1000]
-let testList1_takeNth_NotEqual         = [5; 6; 7; 10]
-let testList1_skipNth_Equal            = [1337; 14; 23; 69; 2; 3; 9001; 23]
-let testList1_skipNth_NotEqual         = [5; 6; 7; 10]
+let testList1                           = [1337; 14; 23; 23; 69; 1; 2; 3; 1000; 9001; 23]
+                                        
+let testList1_filteri_Equal             = [14; 23; 23; 69]
+let testList1_filteri_NotEqual          = [1337; 14; 23;]
+let testList1_choosei_Equal             = [14.; 23.; 23.; 69.]
+let testList1_choosei_NotEqual          = [1337.; 14.; 23.;]
+let testList1_findIndices_Equal         = [1; 2; 3; 4; 5; 6; 7; 10]
+let testList1_findIndices_NotEqual      = [5; 6; 7; 10]
+let testList1_findIndicesBack_Equal     = [10; 7; 6; 5; 4; 3; 2; 1]
+let testList1_findIndicesBack_NotEqual  = [5; 6; 7; 10]
+let testList1_takeNth_Equal             = [23; 1; 1000]
+let testList1_takeNth_NotEqual          = [5; 6; 7; 10]
+let testList1_skipNth_Equal             = [1337; 14; 23; 69; 2; 3; 9001; 23]
+let testList1_skipNth_NotEqual          = [5; 6; 7; 10]
+let testList1_groupWhen_Equal           = [[1337; 14]; [23]; [23]; [69]; [1; 2]; [3; 1000]; [9001]; [23]]
+let testList1_groupWhen_NotEuqal        = [[1337; 14]; [23]; [23]; [69]; [1; 2]; [3; 1000]; [9001; 23]]
 
 [<Tests>]
 let listTests =
@@ -83,6 +85,15 @@ let listTests =
             )
             testCase "returns incorrect list" (fun _ ->
                 Expect.notEqual (testList1 |> List.skipNth 3) testList1_skipNth_NotEqual "List.skipNth did not return incorrect List"
+            )
+        ]
+        testList "List.groupWhen" [
+            let isOdd n = n % 2 <> 0
+            testCase "returns correct jagged list" (fun _ ->
+                Expect.equal (testList1 |> List.groupWhen isOdd) testList1_groupWhen_Equal "List.groupWhen did return correct JaggedList"
+            )
+            testCase "returns incorrect jagged list" (fun _ ->
+                Expect.notEqual (testList1 |> List.groupWhen isOdd) testList1_groupWhen_NotEuqal "List.groupWhen did not return incorrect JaggedList"
             )
         ]
     ]

--- a/tests/FSharpAux.Tests/ListTests.fs
+++ b/tests/FSharpAux.Tests/ListTests.fs
@@ -27,7 +27,7 @@ let listTests =
             testCase "returns correct list" (fun _ ->
                 Expect.equal (testList1 |> List.filteri (fun i t -> i < 5 && t < 100)) testList1_filteri_Equal "List.filteri did return correct List"
             )
-            testCase "returns incorrect list" (fun _ ->
+            testCase "does not return incorrect list" (fun _ ->
                 Expect.notEqual (testList1 |> List.filteri (fun i t -> i < 5 && t < 100)) testList1_filteri_NotEqual "List.filteri did not return incorrect List"
             )
         ]
@@ -35,7 +35,7 @@ let listTests =
             testCase "returns correct list" (fun _ ->
                 Expect.equal (testList1 |> List.countByPredicate (fun t -> t < 100)) 8 "List.countByPredicate did return correct integer"
             )
-            testCase "returns incorrect list" (fun _ ->
+            testCase "does not return incorrect list" (fun _ ->
                 Expect.notEqual (testList1 |> List.countByPredicate (fun t -> t < 100)) 5 "List.countByPredicate did not return incorrect integer"
             )
         ]
@@ -43,7 +43,7 @@ let listTests =
             testCase "returns correct list" (fun _ ->
                 Expect.equal (testList1 |> List.countiByPredicate (fun i t -> i < 5 && t < 100)) 4 "List.countiByPredicate did return correct integer"
             )
-            testCase "returns incorrect list" (fun _ ->
+            testCase "does not return incorrect list" (fun _ ->
                 Expect.notEqual (testList1 |> List.countiByPredicate (fun i t -> i < 5 && t < 100)) 1 "List.countiByPredicate did not return incorrect integer"
             )
         ]
@@ -51,7 +51,7 @@ let listTests =
             testCase "returns correct list" (fun _ ->
                 Expect.equal (testList1 |> List.choosei (fun i t -> if i < 5 && t < 100 then Some (float t) else None)) testList1_choosei_Equal "List.choosei did return correct List"
             )
-            testCase "returns incorrect list" (fun _ ->
+            testCase "does not return incorrect list" (fun _ ->
                 Expect.notEqual (testList1 |> List.choosei (fun i t -> if i < 5 && t < 100 then Some (float t) else None)) testList1_choosei_NotEqual "List.choosei did not return incorrect List"
             )
         ]
@@ -59,7 +59,7 @@ let listTests =
             testCase "returns correct list" (fun _ ->
                 Expect.equal (testList1 |> List.findIndices (fun t -> t < 100)) testList1_findIndices_Equal "List.findIndices did return correct List"
             )
-            testCase "returns incorrect list" (fun _ ->
+            testCase "does not return incorrect list" (fun _ ->
                 Expect.notEqual (testList1 |> List.findIndices (fun t -> t < 100)) testList1_findIndices_NotEqual "List.findIndices did not return incorrect List"
             )
         ]
@@ -67,7 +67,7 @@ let listTests =
             testCase "returns correct list" (fun _ ->
                 Expect.equal (testList1 |> List.findIndicesBack (fun t -> t < 100)) testList1_findIndicesBack_Equal "List.findIndicesBack did return correct List"
             )
-            testCase "returns incorrect list" (fun _ ->
+            testCase "does not return incorrect list" (fun _ ->
                 Expect.notEqual (testList1 |> List.findIndicesBack (fun t -> t < 100)) testList1_findIndicesBack_NotEqual "List.findIndicesBack did not return incorrect List"
             )
         ]
@@ -75,7 +75,7 @@ let listTests =
             testCase "returns correct list" (fun _ ->
                 Expect.equal (testList1 |> List.takeNth 3) testList1_takeNth_Equal "List.takeNth did return correct List"
             )
-            testCase "returns incorrect list" (fun _ ->
+            testCase "does not return incorrect list" (fun _ ->
                 Expect.notEqual (testList1 |> List.takeNth 3) testList1_takeNth_NotEqual "List.takeNth did not return incorrect List"
             )
         ]
@@ -83,7 +83,7 @@ let listTests =
             testCase "returns correct list" (fun _ ->
                 Expect.equal (testList1 |> List.skipNth 3) testList1_skipNth_Equal "List.skipNth did return correct List"
             )
-            testCase "returns incorrect list" (fun _ ->
+            testCase "does not return incorrect list" (fun _ ->
                 Expect.notEqual (testList1 |> List.skipNth 3) testList1_skipNth_NotEqual "List.skipNth did not return incorrect List"
             )
         ]
@@ -92,7 +92,7 @@ let listTests =
             testCase "returns correct jagged list" (fun _ ->
                 Expect.equal (testList1 |> List.groupWhen isOdd) testList1_groupWhen_Equal "List.groupWhen did return correct JaggedList"
             )
-            testCase "returns incorrect jagged list" (fun _ ->
+            testCase "does not return incorrect jagged list" (fun _ ->
                 Expect.notEqual (testList1 |> List.groupWhen isOdd) testList1_groupWhen_NotEuqal "List.groupWhen did not return incorrect JaggedList"
             )
         ]

--- a/tests/FSharpAux.Tests/MathTests.fs
+++ b/tests/FSharpAux.Tests/MathTests.fs
@@ -10,7 +10,7 @@ let mathTests =
             testCase "returns correct float" (fun _ ->
                 Expect.equal (Math.nthRoot 3 27.) 3. "Math.nthRoot did return correct float"
             )
-            testCase "returns incorrect float" (fun _ ->
+            testCase "does not return incorrect float" (fun _ ->
                 Expect.notEqual (Math.nthRoot 3 27.) 9. "Math.nthRoot did not return incorrect float"
             )
         ]

--- a/tests/FSharpAux.Tests/SeqTests.fs
+++ b/tests/FSharpAux.Tests/SeqTests.fs
@@ -30,25 +30,25 @@ let seqTests =
             testCase "returns correct jagged list, case1: [3; 3; 2; 4; 1; 2]" (fun _ ->
                 Expect.equal (testSeq2 |> Seq.groupWhen isOdd |> list2) (testSeq2_groupWhen_Equal |> list2) "Seq.groupWhen did return correct jagged list"
             )
-            testCase "returns incorrect jagged list, case1: [3; 3; 2; 4; 1; 2]" (fun _ ->
+            testCase "does not return incorrect jagged list, case1: [3; 3; 2; 4; 1; 2]" (fun _ ->
                 Expect.notEqual (testSeq2 |> Seq.groupWhen isOdd |> list2) (testSeq2_groupWhen_NotEqual |> list2) "Seq.groupWhen did not return incorrect jagged list"
             )
             testCase "returns correct jagged list, case2: [3; 3; 2; 4; 1; 1]" (fun _ ->
                 Expect.equal (testSeq3 |> Seq.groupWhen isOdd |> list2) (testSeq3_groupWhen_Equal |> list2) "Seq.groupWhen did return correct jagged list"
             )
-            testCase "returns incorrect jagged list, case2: [3; 3; 2; 4; 1; 1]" (fun _ ->
+            testCase "does not return incorrect jagged list, case2: [3; 3; 2; 4; 1; 1]" (fun _ ->
                 Expect.notEqual (testSeq3 |> Seq.groupWhen isOdd |> list2) (testSeq3_groupWhen_NotEqual |> list2) "Seq.groupWhen did not return incorrect jagged list"
             )
             testCase "returns correct jagged list, case3: [3; 3; 2; 4; 2; 2]" (fun _ ->
                 Expect.equal (testSeq4 |> Seq.groupWhen isOdd |> list2) (testSeq4_groupWhen_Equal |> list2) "Seq.groupWhen did return correct jagged list"
             )
-            testCase "returns incorrect jagged list, case3: [3; 3; 2; 4; 2; 2]" (fun _ ->
+            testCase "does not return incorrect jagged list, case3: [3; 3; 2; 4; 2; 2]" (fun _ ->
                 Expect.notEqual (testSeq4 |> Seq.groupWhen isOdd |> list2) (testSeq4_groupWhen_NotEqual |> list2) "Seq.groupWhen did not return incorrect jagged list"
             )
             testCase "returns correct jagged list, case4: [3; 3; 2; 4; 2; 1]" (fun _ ->
                 Expect.equal (testSeq5 |> Seq.groupWhen isOdd |> list2) (testSeq5_groupWhen_Equal |> list2) "Seq.groupWhen did return correct jagged list"
             )
-            testCase "returns incorrect jagged list, case4: [3; 3; 2; 4; 2; 1]" (fun _ ->
+            testCase "does not return incorrect jagged list, case4: [3; 3; 2; 4; 2; 1]" (fun _ ->
                 Expect.notEqual (testSeq5 |> Seq.groupWhen isOdd |> list2) (testSeq5_groupWhen_NotEqual |> list2) "Seq.groupWhen did not return incorrect jagged list"
             )
         ]

--- a/tests/FSharpAux.Tests/SeqTests.fs
+++ b/tests/FSharpAux.Tests/SeqTests.fs
@@ -1,0 +1,27 @@
+﻿module SeqTests
+
+open FSharpAux
+open Expecto
+
+let testSeq1                            = seq {1337; 14; 23; 23; 69; 1; 2; 3; 1000; 9001; 23}
+let testSeq2                            = seq {3; 3; 2; 4; 1; 2}
+let testSeq3                            = seq {3; 3; 2; 4; 1; 1}
+let testSeq4                            = seq {3; 3; 2; 4; 2; 2}
+let testSeq5                            = seq {3; 3; 2; 4; 2; 1}
+
+let testSeq2_groupWhen_Equal            = seq {seq {1337; 14}; seq {23}; seq {23}; seq {69}; seq {1; 2}; seq {3; 1000}; seq {9001; 23}}
+let testSeq2_groupWhen_NotEqual         = seq {seq {1337; 14}; seq {23}; seq {23}; seq {69}; seq {1; 2}; seq {3; 1000}; seq {9001; 23}}
+
+[<Tests>]
+let seqTests =
+    testList "SeqTests" [
+        let isOdd = fun n -> n % 2 <> 0
+        testList "Seq.groupWhen" [
+            testCase "returns correct list" (fun _ ->
+                Expect.equal (testSeq1 |> Seq.groupWhen isOdd) testSeq1_groupWhen_Equal "Seq.groupWhen did return correct jagged sequence"
+            )
+            testCase "returns incorrect list" (fun _ ->
+                Expect.notEqual (testSeq1 |> Seq.groupWhen isOdd) testList1_filteri_NotEqual "Seq.groupWhen did not return incorrect jagged sequence"
+            )
+        ]
+    ]

--- a/tests/FSharpAux.Tests/SeqTests.fs
+++ b/tests/FSharpAux.Tests/SeqTests.fs
@@ -9,19 +9,47 @@ let testSeq3                            = seq {3; 3; 2; 4; 1; 1}
 let testSeq4                            = seq {3; 3; 2; 4; 2; 2}
 let testSeq5                            = seq {3; 3; 2; 4; 2; 1}
 
-let testSeq2_groupWhen_Equal            = seq {seq {1337; 14}; seq {23}; seq {23}; seq {69}; seq {1; 2}; seq {3; 1000}; seq {9001; 23}}
-let testSeq2_groupWhen_NotEqual         = seq {seq {1337; 14}; seq {23}; seq {23}; seq {69}; seq {1; 2}; seq {3; 1000}; seq {9001; 23}}
+let testSeq2_groupWhen_Equal            = seq {seq {3}; seq {3; 2; 4}; seq {1; 2}}
+let testSeq2_groupWhen_NotEqual         = seq {seq {3}; seq {3; 2; 4}; seq {1}; seq {2}}
+let testSeq3_groupWhen_Equal            = seq {seq {3}; seq {3; 2; 4}; seq {1}; seq {1}}
+let testSeq3_groupWhen_NotEqual         = seq {seq {3}; seq {3; 2; 4}; seq {1; 1}}
+let testSeq4_groupWhen_Equal            = seq {seq {3}; seq {3; 2; 4; 2; 2}}
+let testSeq4_groupWhen_NotEqual         = seq {seq {3}; seq {3; 2; 4; 2}; seq {2}}
+let testSeq5_groupWhen_Equal            = seq {seq {3}; seq {3; 2; 4; 2}; seq {1}}
+let testSeq5_groupWhen_NotEqual         = seq {seq {3}; seq {3; 2; 4; 2; 1}}
+
+// helper functions
+let list s = Seq.toList s
+let list2 s = Seq.map (Seq.toList) s |> Seq.toList
 
 [<Tests>]
 let seqTests =
     testList "SeqTests" [
         let isOdd = fun n -> n % 2 <> 0
         testList "Seq.groupWhen" [
-            testCase "returns correct list" (fun _ ->
-                Expect.equal (testSeq1 |> Seq.groupWhen isOdd) testSeq1_groupWhen_Equal "Seq.groupWhen did return correct jagged sequence"
+            testCase "returns correct jagged list, case1: [3; 3; 2; 4; 1; 2]" (fun _ ->
+                Expect.equal (testSeq2 |> Seq.groupWhen isOdd |> list2) (testSeq2_groupWhen_Equal |> list2) "Seq.groupWhen did return correct jagged list"
             )
-            testCase "returns incorrect list" (fun _ ->
-                Expect.notEqual (testSeq1 |> Seq.groupWhen isOdd) testList1_filteri_NotEqual "Seq.groupWhen did not return incorrect jagged sequence"
+            testCase "returns incorrect jagged list, case1: [3; 3; 2; 4; 1; 2]" (fun _ ->
+                Expect.notEqual (testSeq2 |> Seq.groupWhen isOdd |> list2) (testSeq2_groupWhen_NotEqual |> list2) "Seq.groupWhen did not return incorrect jagged list"
+            )
+            testCase "returns correct jagged list, case2: [3; 3; 2; 4; 1; 1]" (fun _ ->
+                Expect.equal (testSeq3 |> Seq.groupWhen isOdd |> list2) (testSeq3_groupWhen_Equal |> list2) "Seq.groupWhen did return correct jagged list"
+            )
+            testCase "returns incorrect jagged list, case2: [3; 3; 2; 4; 1; 1]" (fun _ ->
+                Expect.notEqual (testSeq3 |> Seq.groupWhen isOdd |> list2) (testSeq3_groupWhen_NotEqual |> list2) "Seq.groupWhen did not return incorrect jagged list"
+            )
+            testCase "returns correct jagged list, case3: [3; 3; 2; 4; 2; 2]" (fun _ ->
+                Expect.equal (testSeq4 |> Seq.groupWhen isOdd |> list2) (testSeq4_groupWhen_Equal |> list2) "Seq.groupWhen did return correct jagged list"
+            )
+            testCase "returns incorrect jagged list, case3: [3; 3; 2; 4; 2; 2]" (fun _ ->
+                Expect.notEqual (testSeq4 |> Seq.groupWhen isOdd |> list2) (testSeq4_groupWhen_NotEqual |> list2) "Seq.groupWhen did not return incorrect jagged list"
+            )
+            testCase "returns correct jagged list, case4: [3; 3; 2; 4; 2; 1]" (fun _ ->
+                Expect.equal (testSeq5 |> Seq.groupWhen isOdd |> list2) (testSeq5_groupWhen_Equal |> list2) "Seq.groupWhen did return correct jagged list"
+            )
+            testCase "returns incorrect jagged list, case4: [3; 3; 2; 4; 2; 1]" (fun _ ->
+                Expect.notEqual (testSeq5 |> Seq.groupWhen isOdd |> list2) (testSeq5_groupWhen_NotEqual |> list2) "Seq.groupWhen did not return incorrect jagged list"
             )
         ]
     ]

--- a/tests/FSharpAux.Tests/StringTests.fs
+++ b/tests/FSharpAux.Tests/StringTests.fs
@@ -18,7 +18,7 @@ let stringTests =
             testCase "does start with" (fun _ ->
                 Expect.isTrue ("Hi there!" |> String.startsWith "Hi ") "String.startsWith did not return true for proper substring"
             )
-            testCase "does not start with" (fun _ ->
+            testCase "does not fail to start with" (fun _ ->
                 Expect.isFalse ("Hi there!" |> String.startsWith "soos") "String.startsWith did not return false for improper substring"
             )
         ]
@@ -26,7 +26,7 @@ let stringTests =
             testCase "replaces" (fun _ ->
                 Expect.equal ("Hi there!" |> String.replace "Hi " "Yo ") "Yo there!" "String.replaces did return correct replacement"
             )
-            testCase "does not replace" (fun _ ->
+            testCase "does not fail to replace" (fun _ ->
                 Expect.notEqual ("Hi there!" |> String.replace "soos" "Yo") "Yo there!" "String.replaces did not return incorrect replacement"
             )
         ]
@@ -34,7 +34,7 @@ let stringTests =
             testCase "gives first" (fun _ ->
                 Expect.equal ("Hi there!" |> String.first) 'H' "String.first did return correct Char"
             )
-            testCase "give anything else" (fun _ ->
+            testCase "does not give anything else" (fun _ ->
                 Expect.notEqual ("Hi there!" |> String.first) '!' "String.first did not return incorrect Char"
             )
         ]
@@ -42,7 +42,7 @@ let stringTests =
             testCase "gives last" (fun _ ->
                 Expect.equal ("Hi there!" |> String.last) '!' "String.first did return correct Char"
             )
-            testCase "give anything else" (fun _ ->
+            testCase "does not give anything else" (fun _ ->
                 Expect.notEqual ("Hi there!" |> String.last) 'u' "String.first did not return incorrect Char"
             )
         ]
@@ -50,7 +50,7 @@ let stringTests =
             testCase "splits correctly" (fun _ ->
                 Expect.equal ("Hi there!" |> String.splitS " t") [|"Hi"; "here!"|] "String.splitS did return correct string array"
             )
-            testCase "splits incorrectly" (fun _ ->
+            testCase "does not splits incorrectly" (fun _ ->
                 Expect.notEqual ("Hi there!" |> String.splitS " t") [|"Hi "; "there!"|] "String.first did not return incorrect string array"
             )
         ]
@@ -58,7 +58,7 @@ let stringTests =
             testCase "finds correct index" (fun _ ->
                 Expect.equal ("Hi there!" |> String.findIndexBack ' ') 2 "String.findIndexBack did return correct index"
             )
-            testCase "finds incorrect index" (fun _ ->
+            testCase "does not find incorrect index" (fun _ ->
                 Expect.notEqual ("Hi there!" |> String.findIndexBack ' ') 3 "String.findIndexBack did not return incorrect index"
             )
         ]
@@ -66,7 +66,7 @@ let stringTests =
             testCase "finds correct index" (fun _ ->
                 Expect.equal ("Hi there!" |> String.findIndex ' ') 2 "String.findIndex did return correct index"
             )
-            testCase "finds incorrect index" (fun _ ->
+            testCase "does not find incorrect index" (fun _ ->
                 Expect.notEqual ("Hi there!" |> String.findIndex ' ') 3 "String.findIndex did not return incorrect index"
             )
         ]
@@ -74,7 +74,7 @@ let stringTests =
             testCase "finds correct indices" (fun _ ->
                 Expect.equal ("Hi there!" |> String.findIndices 'e') [|5; 7|] "String.findIndices did return correct indices"
             )
-            testCase "finds incorrect indices" (fun _ ->
+            testCase "does not find incorrect indices" (fun _ ->
                 Expect.notEqual ("Hi there!" |> String.findIndices 'e') [|0; 1|] "String.findIndices did not return incorrect indices"
             )
         ]
@@ -82,7 +82,7 @@ let stringTests =
             testCase "finds correct indices" (fun _ ->
                 Expect.equal ("Hi there!" |> String.findIndicesBack 'e') [|7; 5|] "String.findIndicesBack did return correct indices"
             )
-            testCase "finds incorrect indices" (fun _ ->
+            testCase "does not find incorrect indices" (fun _ ->
                 Expect.notEqual ("Hi there!" |> String.findIndicesBack 'e') [|0; 1|] "String.findIndicesBack did not return incorrect indices"
             )
         ]
@@ -90,7 +90,7 @@ let stringTests =
             testCase "finds correct substring" (fun _ ->
                 Expect.equal ("Hi there!" |> String.takeWhile ((=) 'H')) "H" "String.takeWhile did return correct substring"
             )
-            testCase "finds incorrect substring" (fun _ ->
+            testCase "does not find incorrect substring" (fun _ ->
                 Expect.notEqual ("Hi there!" |> String.takeWhile ((=) 'H')) "fdsfds" "String.takeWhile did not return incorrect substring"
             )
         ]
@@ -98,7 +98,7 @@ let stringTests =
             testCase "finds correct substring" (fun _ ->
                 Expect.equal ("Hi there!" |> String.skipWhile ((=) 'H')) "i there!" "String.skipWhile did return correct substring"
             )
-            testCase "finds incorrect substring" (fun _ ->
+            testCase "does not find incorrect substring" (fun _ ->
                 Expect.notEqual ("Hi there!" |> String.skipWhile ((=) 'H')) "fdsfds" "String.skipWhile did not return incorrect substring"
             )
         ]


### PR DESCRIPTION
- Fixes #17
- Also adds corresponding functions in `List` and `Array` modules 
- Adds some triple-slash documentation to the modules `Seq`, `List`, and `Array`
- Adds unit tests for every new function
- Comments `Array.contains` out due to already being present in `Microsoft.FSharp.Core` namespace