### PR TITLE
Fable

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,8 @@ subgraph TestSuites
     M -- on transpiled files --> A
 end
 subgraph Packages
-    E("FSharpAux.Fable [includes Fable folder]")
-    F("FSharpAux.Core [.NET dll only]")
+    F("FSharpAux.Core [includes Fable folder]")
     G("FSharpAux")
-    A -- packages --> E
     A -- packages --> F
     B -- packages --> G
     F -- nuget dependency --- G

--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ The documentation can be found [here.](http://csbiology.github.io/FSharpAux)
 
 The documentation for this library is automatically generated (using the F# Formatting) from *.fsx and *.md files in the docs folder. If you find a typo, please submit a pull request!
 
+## Nuget 
+
+| Package Name         | Nuget                                                                                                                |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `FSharpAux.Core`      | [![NuGet Badge](https://buildstats.info/nuget/FSharpAux.Core)](https://www.nuget.org/packages/FSharpAux.Core/) |
+| `FSharpAux`           | [![NuGet Badge](https://buildstats.info/nuget/FSharpAux)](https://www.nuget.org/packages/FSharpAux/) |
+
 ## Develop
 
 ### ProjectDescription

--- a/build/PackageTasks.fs
+++ b/build/PackageTasks.fs
@@ -29,24 +29,6 @@ let pack = BuildTask.create "Pack" [clean; build; runTests] {
                         OutputPath = Some pkgDir
                 }
             ))
-            // This is used to create FSharpAux.Fable with the Fable subfolder as explained here:
-            // https://fable.io/docs/your-fable-project/author-a-fable-library.html
-            fableProject
-            |> Fake.DotNet.DotNet.pack (fun p ->
-                let msBuildParams =
-                    {p.MSBuildParams with 
-                        Properties = ([
-                            "PackageId", fableProjectName
-                            "Version",stableVersionTag
-                            "PackageReleaseNotes",  (release.Notes |> String.concat "\r\n")
-                        ] @ p.MSBuildParams.Properties)
-                    }
-                {
-                    p with 
-                        MSBuildParams = msBuildParams
-                        OutputPath = Some pkgDir
-                }
-            )
     else failwith "aborted"
 }
 
@@ -70,25 +52,6 @@ let packPrerelease = BuildTask.create "PackPrerelease" [setPrereleaseTag; clean;
                                 MSBuildParams = msBuildParams
                         }
             ))
-            // This is used to create ISADotNet.Fable with the Fable subfolder as explained here:
-            // https://fable.io/docs/your-fable-project/author-a-fable-library.html
-            fableProject
-            |> Fake.DotNet.DotNet.pack (fun p ->
-                let msBuildParams =
-                    {p.MSBuildParams with 
-                        Properties = ([
-                            "PackageId", fableProjectName
-                            "Version", prereleaseTag
-                            "PackageReleaseNotes",  (release.Notes |> String.toLines)
-                        ] @ p.MSBuildParams.Properties)
-                    }
-                {
-                    p with 
-                        VersionSuffix = Some prereleaseSuffix
-                        OutputPath = Some pkgDir
-                        MSBuildParams = msBuildParams
-                }
-            )
     else
         failwith "aborted"
 }

--- a/src/FSharpAux.Core/FSharpAux.Core.fsproj
+++ b/src/FSharpAux.Core/FSharpAux.Core.fsproj
@@ -1,14 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <OutputType>Library</OutputType>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <!-- Optional: Declare that the Repository URL can be published to NuSpec -->
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <!-- Optional: Embed source files that are not tracked by the source control manager to the PDB -->
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <!-- Optional: Include PDB in the built .nupkg -->
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+  	<TargetFramework>netstandard2.0</TargetFramework>
+  	<Authors>Kevin Schneider, Timo Mühlhaus, Oliver Maus, Kevin Frey, Jonathan Ott, David Zimmer, Benedikt Venn, Heinrich Lukas Weil</Authors>
+  	<Description>Extensions, auxiliary functions and data structures for the F# programming language.</Description>
+  	<Summary>Extensions, auxiliary functions and data structures for the F# programming language.</Summary>
+  	<PackageLicenseExpression>MIT</PackageLicenseExpression>
+  	<PackageTags>F#;FSharp;fable;fable-library;fable-javascript</PackageTags>
+  	<RepositoryUrl>https://github.com/CSBiology/FsSpreadsheet</RepositoryUrl>
+  	<GenerateDocumentationFile>true</GenerateDocumentationFile>
+  	<!-- Optional: Declare that the Repository URL can be published to NuSpec -->
+  	<PublishRepositoryUrl>true</PublishRepositoryUrl>
+  	<!-- Optional: Embed source files that are not tracked by the source control manager to the PDB -->
+  	<EmbedUntrackedSources>true</EmbedUntrackedSources>
+  	<!-- Optional: Include PDB in the built .nupkg -->
+  	<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+  	<OutputType>Library</OutputType>
+  	<RepositoryType>git</RepositoryType>
   </PropertyGroup>
 	
   <ItemGroup>

--- a/src/FSharpAux.Core/FSharpAux.Core.fsproj
+++ b/src/FSharpAux.Core/FSharpAux.Core.fsproj
@@ -39,7 +39,7 @@
   </ItemGroup>
 
   <!-- Required for Fable compatibility -->
-  <ItemGroup Condition=" '$(PackageId)' == 'FSharpAux.Fable' ">
+  <ItemGroup>
   	<Content Include="*.fsproj; **\*.fs; **\*.fsi" PackagePath="fable\" />
   </ItemGroup>
 </Project>

--- a/src/FSharpAux/FSharpAux.fsproj
+++ b/src/FSharpAux/FSharpAux.fsproj
@@ -1,10 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>FSharpAux</RootNamespace>
     <AssemblyName>FSharpAux</AssemblyName>
     <Name>FSharpAux</Name>
-    <OutputType>Library</OutputType>
+  	<Authors>Kevin Schneider, Timo Mühlhaus, Oliver Maus, Kevin Frey, Jonathan Ott, David Zimmer, Benedikt Venn, Heinrich Lukas Weil</Authors>
+  	<Description>Extensions, auxiliary functions and data structures for the F# programming language.</Description>
+  	<Summary>Extensions, auxiliary functions and data structures for the F# programming language.</Summary>
+  	<PackageLicenseExpression>MIT</PackageLicenseExpression>
+  	<PackageTags>F#;FSharp</PackageTags>
+  	<RepositoryUrl>https://github.com/CSBiology/FsSpreadsheet</RepositoryUrl>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Optional: Declare that the Repository URL can be published to NuSpec -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -12,6 +18,8 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <!-- Optional: Include PDB in the built .nupkg -->
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <OutputType>Library</OutputType>
+  	<RepositoryType>git</RepositoryType>
   </PropertyGroup>
 	
   <ItemGroup>


### PR DESCRIPTION
- Remove split of FSharpAux.Core in two nuget packages, one with and one without .fs source files.
--> Now always with .fs source files
- Add nuget packages to README.md
- Add metadata to FSharpAux.Core and FSharpAux MsBuild